### PR TITLE
Dump light data for 1.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 package-lock.json
+dumps
+launcher_accounts.json

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class ChunkDumper extends EventEmitter {
     super()
     this.version = version.toString()
     this.mcData = require('minecraft-data')(this.version)
-    this.withLightPackets = this.mcData.isNewerOrEqualTo('1.14')
+    this.withLightPackets = this.mcData.isNewerOrEqualTo('1.14') && this.mcData.isOlderThan('1.18')
   }
 
   async start () {
@@ -37,8 +37,8 @@ class ChunkDumper extends EventEmitter {
       version: this.version,
       port: 25569
     })
-    this.client.on('map_chunk', ({ x, z, groundUp, bitMap, biomes, chunkData, heightMaps }) => {
-      this.emit('chunk', ({ x, z, groundUp, bitMap, biomes, chunkData, heightMaps }))
+    this.client.on('map_chunk', ({ x, z, groundUp, bitMap, biomes, chunkData, heightmaps, skyLightMask, blockLightMask, emptySkyLightMask, emptyBlockLightMask, skyLight, blockLight, trustEdges }) => {
+      this.emit('chunk', ({ x, z, groundUp, bitMap, biomes, chunkData, heightmaps, skyLightMask, blockLightMask, emptySkyLightMask, emptyBlockLightMask, skyLight, blockLight, trustEdges }))
     })
     this.client.on('update_light', ({ chunkX, chunkZ, skyLightMask, blockLightMask, emptySkyLightMask, emptyBlockLightMask, skyLight, blockLight, data, trustEdges }) => {
       this.emit('chunk_light', ({ chunkX, chunkZ, skyLightMask, blockLightMask, emptySkyLightMask, emptyBlockLightMask, skyLight, blockLight, data, trustEdges }))
@@ -83,7 +83,7 @@ class ChunkDumper extends EventEmitter {
         let finished = false
 
         if ((chunksSaved.size === count && !this.withLightPackets) || (([...lightsSaved].filter(x => chunksSaved.has(x))).length >= count &&
-         this.withLightPackets)) {
+          this.withLightPackets)) {
           this.removeListener('chunk', saveChunk)
           if (this.withLightPackets) {
             this.removeListener('chunk_light', saveChunkLight)
@@ -173,10 +173,10 @@ class ChunkDumper extends EventEmitter {
       path.join(folder, 'chunk_' + x + '_' + z + '.meta'), d)
   }
 
-  static async saveChunkFiles (chunkDataFile, chunkMetaFile, { x, z, groundUp, bitMap, biomes, ignoreOldData, heightMaps, chunkData }) {
+  static async saveChunkFiles (chunkDataFile, chunkMetaFile, { x, z, groundUp, bitMap, biomes, ignoreOldData, heightmaps, chunkData, skyLightMask, blockLightMask, emptySkyLightMask, emptyBlockLightMask, skyLight, blockLight, trustEdges }) {
     await fs.writeFile(chunkDataFile, chunkData)
     await fs.writeFile(chunkMetaFile, JSON.stringify({
-      x, z, groundUp, bitMap, biomes, ignoreOldData, heightMaps, chunkData
+      x, z, groundUp, bitMap, biomes, ignoreOldData, heightmaps, chunkData, skyLightMask, blockLightMask, emptySkyLightMask, emptyBlockLightMask, skyLight, blockLight, trustEdges
     }), 'utf8')
   }
 


### PR DESCRIPTION
Nearly identical to https://github.com/PrismarineJS/minecraft-chunk-dumper/pull/25, with the required check in the constructor to not dump light packets and some misc formatting changes.

Also some convenient `.gitignore`s for running chunk-dumper out of the folder you're coding in